### PR TITLE
Changed return type of GetVehicleParamsSirenState to int

### DIFF
--- a/lib/sampgdk/a_vehicles.idl
+++ b/lib/sampgdk/a_vehicles.idl
@@ -46,7 +46,7 @@ const int VEHICLE_PARAMS_ON    =  1;
 [native] bool ManualVehicleEngineAndLights();
 [native] bool SetVehicleParamsEx([in] int vehicleid, [in] bool engine, [in] bool lights, [in] bool alarm, [in] bool doors, [in] bool bonnet, [in] bool boot, [in] bool objective);
 [native] bool GetVehicleParamsEx([in] int vehicleid, [out] int engine, [out] int lights, [out] int alarm, [out] int doors, [out] int bonnet, [out] int boot, [out] int objective);
-[native] bool GetVehicleParamsSirenState([in] int vehicleid);
+[native] int GetVehicleParamsSirenState([in] int vehicleid);
 [native] bool SetVehicleParamsCarDoors([in] int vehicleid, [in] bool driver, [in] bool passenger, [in] bool backleft, [in] bool backright);
 [native] bool GetVehicleParamsCarDoors([in] int vehicleid, [out] int driver, [out] int passenger, [out] int backleft, [out] int backright);
 [native] bool SetVehicleParamsCarWindows([in] int vehicleid, [in] bool driver, [in] bool passenger, [in] bool backleft, [in] bool backright);


### PR DESCRIPTION
GetVehicleParamsSirenState returns a state (-1: unset,0: off,1: on). If a vehicle has just been spawned, the siren state is -1. The bool conversion would result in true, while the siren isn't actually on. MP2 has placed a warning on the wiki about this specific topic.