### PR TITLE
Fixes the handling of the return value of OnPublicCall

### DIFF
--- a/lib/sampgdk/internal/callback.c
+++ b/lib/sampgdk/internal/callback.c
@@ -186,7 +186,7 @@ bool sampgdk_callback_invoke(AMX *amx,
     func = sampgdk_plugin_get_symbol(plugins[i], callback_filter->name);
     if (func != NULL
         && !((_sampgdk_callback_filter)func)(amx, name, params, retval)) {
-      continue;
+      return false;
     }
 
     if (callback == NULL || callback->handler == NULL) {


### PR DESCRIPTION
If I understand the intended meaning of the return value OnPublicCall correctly, then callbacks should not be handled in the game mode if false is returned in OnPublicCall. Calls however are still handled by the game mode when false is returned. This should fix that.

Fixes #156