### PR TITLE
Fixed compilation errors when trying to compile as C++ code

### DIFF
--- a/lib/sampgdk/core.c
+++ b/lib/sampgdk/core.c
@@ -33,6 +33,7 @@
 #undef sampgdk_ProcessTick
 
 #ifdef _MSC_VER
+  #include <intrin.h>
   #define _SAMPGDK_RETURN_ADDRESS() _ReturnAddress()
 #else
   #define _SAMPGDK_RETURN_ADDRESS() __builtin_return_address(0)
@@ -49,8 +50,8 @@
 static void _sampgdk_init(void **plugin_data) {
   int error;
 
-  sampgdk_logprintf_impl = plugin_data[PLUGIN_DATA_LOGPRINTF];
-  sampgdk_amx_api = plugin_data[PLUGIN_DATA_AMX_EXPORTS];
+  sampgdk_logprintf_impl = (logprintf_t)plugin_data[PLUGIN_DATA_LOGPRINTF];
+  sampgdk_amx_api = (struct sampgdk_amx_api *)plugin_data[PLUGIN_DATA_AMX_EXPORTS];
 
   error = sampgdk_module_init();
   if (error  < 0) {

--- a/lib/sampgdk/internal/amxhooks.c
+++ b/lib/sampgdk/internal/amxhooks.c
@@ -95,7 +95,7 @@ static int AMXAPI _sampgdk_amxhooks_Register(AMX *amx,
   sampgdk_log_info("Registered %d natives", i);
 
   return SAMPGDK_HOOK_CALL_CC(_sampgdk_amxhooks_Register_hook, int, AMXAPI,
-                              (amx, nativelist, number));
+                              (AMX *, const AMX_NATIVE_INFO *, int), (amx, nativelist, number));
 }
 
 static int AMXAPI _sampgdk_amxhooks_FindPublic(AMX *amx,
@@ -108,7 +108,7 @@ static int AMXAPI _sampgdk_amxhooks_FindPublic(AMX *amx,
   sampgdk_log_debug("amx_FindPublic(%p, \"%s\", %p)", amx, name, index);
 
   error = SAMPGDK_HOOK_CALL_CC(_sampgdk_amxhooks_FindPublic_hook, int, AMXAPI,
-                               (amx, name, index));
+                               (AMX *, const char *, int *), (amx, name, index));
   sampgdk_log_debug("amx_FindPublic returned %d", error);
 
   /* We are interested in intercepting public calls against the following
@@ -213,7 +213,7 @@ static int AMXAPI _sampgdk_amxhooks_Exec(AMX *amx, cell *retval, int index) {
   if (do_exec) {
     amx->paramcount = paramcount;
     error = SAMPGDK_HOOK_CALL_CC(_sampgdk_amxhooks_Exec_hook, int, AMXAPI,
-                                 (amx, retval, index));
+                                 (AMX *, cell *, int), (amx, retval, index));
     sampgdk_log_debug("amx_Exec returned %d", error);
   }
 
@@ -261,7 +261,7 @@ static int AMXAPI _sampgdk_amxhooks_Allot(AMX *amx,
     error =  AMX_ERR_MEMORY;
   } else {
     error = SAMPGDK_HOOK_CALL_CC(_sampgdk_amxhooks_Allot_hook, int, AMXAPI,
-                                 (amx, cells, amx_addr, phys_addr));
+                                 (AMX *, int, cell *, cell **), (amx, cells, amx_addr, phys_addr));
     sampgdk_log_debug("amx_Allot returned %d", error);
   }
 
@@ -277,7 +277,7 @@ static int AMXAPI _sampgdk_amxhooks_Allot(AMX *amx,
 
     if (resize >= 0) {
       error = SAMPGDK_HOOK_CALL_CC(_sampgdk_amxhooks_Allot_hook, int, AMXAPI,
-                                   (amx, cells, amx_addr, phys_addr));
+                                   (AMX *, int, cell *, cell **), (amx, cells, amx_addr, phys_addr));
     }
   }
 

--- a/lib/sampgdk/internal/callback.c
+++ b/lib/sampgdk/internal/callback.c
@@ -51,7 +51,7 @@ struct _sampgdk_callback_info {
 static struct sampgdk_array _sampgdk_callbacks;
 
 static int _sampgdk_callback_num_callbacks() {
-	return _sampgdk_callbacks.count >= _SAMPGDK_CALLBACK_MAX_RESERVED_INDEXES ? _sampgdk_callbacks.count - _SAMPGDK_CALLBACK_MAX_RESERVED_INDEXES : _sampgdk_callbacks.count - 1;
+  return _sampgdk_callbacks.count - _SAMPGDK_CALLBACK_MAX_RESERVED_INDEXES;
 }
 
 static int _sampgdk_callback_compare_name(const void *key,
@@ -66,7 +66,7 @@ static struct _sampgdk_callback_info *_sampgdk_callback_find(
                                                             const char *name) {
   assert(name != NULL);
 
-  if (_sampgdk_callbacks.count == 0) {
+  if (_sampgdk_callbacks.count < _SAMPGDK_CALLBACK_MAX_RESERVED_INDEXES) {
     return NULL;
   }
 

--- a/lib/sampgdk/internal/callback.c
+++ b/lib/sampgdk/internal/callback.c
@@ -162,7 +162,7 @@ int sampgdk_callback_register(const char *name,
     return -ENOMEM;
   }
 
-  callback.handler = handler;
+  callback.handler = (void *)handler;
   strcpy(callback.name, name);
 
   /* Keep callbacks ordered by name.

--- a/lib/sampgdk/internal/callback.c
+++ b/lib/sampgdk/internal/callback.c
@@ -70,7 +70,7 @@ static struct _sampgdk_callback_info *_sampgdk_callback_find(
     return NULL;
   }
 
-  return bsearch(name,
+  return (struct _sampgdk_callback_info *)bsearch(name,
                  _sampgdk_callbacks.data,
                  _sampgdk_callback_num_callbacks(),
                  _sampgdk_callbacks.elem_size,
@@ -89,7 +89,7 @@ static int _sampgdk_callback_register_special(const char *name) {
     return sampgdk_array_get_index(&_sampgdk_callbacks, ptr);
   }
 
-  callback.name = malloc(strlen(name) + 1);
+  callback.name = (char *)malloc(strlen(name) + 1);
   if (callback.name == NULL) {
     return -ENOMEM;
   }
@@ -135,7 +135,7 @@ SAMPGDK_MODULE_CLEANUP(callback) {
   struct _sampgdk_callback_info *callback;
 
   for (i = 0; i < _sampgdk_callbacks.count; i++) {
-    callback = sampgdk_array_get(&_sampgdk_callbacks, i);
+    callback = (struct _sampgdk_callback_info *)sampgdk_array_get(&_sampgdk_callbacks, i);
     free(callback->name);
   }
 
@@ -157,7 +157,7 @@ int sampgdk_callback_register(const char *name,
     return sampgdk_array_get_index(&_sampgdk_callbacks, ptr);
   }
 
-  callback.name = malloc(strlen(name) + 1);
+  callback.name = (char *)malloc(strlen(name) + 1);
   if (callback.name == NULL) {
     return -ENOMEM;
   }
@@ -170,7 +170,7 @@ int sampgdk_callback_register(const char *name,
    */
   count = _sampgdk_callback_num_callbacks();
   for (i = 0; i < count; i++) {
-    ptr = sampgdk_array_get(&_sampgdk_callbacks, i);
+    ptr = (struct _sampgdk_callback_info *)sampgdk_array_get(&_sampgdk_callbacks, i);
     if (strcmp(name, ptr->name) <= 0) {
       break;
     }
@@ -202,7 +202,7 @@ bool sampgdk_callback_get(int index, char **name) {
     return false;
   }
 
-  callback = sampgdk_array_get(&_sampgdk_callbacks, index);
+  callback = (struct _sampgdk_callback_info *)sampgdk_array_get(&_sampgdk_callbacks, index);
   *name = callback->name;
 
   return true;
@@ -224,9 +224,9 @@ bool sampgdk_callback_invoke(AMX *amx,
   assert(amx != NULL);
 
   callback = _sampgdk_callback_find(name);
-  callback_filter = sampgdk_array_get(&_sampgdk_callbacks,
+  callback_filter = (struct _sampgdk_callback_info *)sampgdk_array_get(&_sampgdk_callbacks,
                                       _SAMPGDK_CALLBACK_INDEX_OPC);
-  callback_filter2 = sampgdk_array_get(&_sampgdk_callbacks,
+  callback_filter2 = (struct _sampgdk_callback_info *)sampgdk_array_get(&_sampgdk_callbacks,
                                        _SAMPGDK_CALLBACK_INDEX_OPC2);
 
   assert(callback_filter != NULL);

--- a/lib/sampgdk/internal/callback.c
+++ b/lib/sampgdk/internal/callback.c
@@ -51,7 +51,7 @@ struct _sampgdk_callback_info {
 static struct sampgdk_array _sampgdk_callbacks;
 
 static int _sampgdk_callback_num_callbacks() {
-  return _sampgdk_callbacks.count - _SAMPGDK_CALLBACK_MAX_RESERVED_INDEXES;
+	return _sampgdk_callbacks.count >= _SAMPGDK_CALLBACK_MAX_RESERVED_INDEXES ? _sampgdk_callbacks.count - _SAMPGDK_CALLBACK_MAX_RESERVED_INDEXES : _sampgdk_callbacks.count - 1;
 }
 
 static int _sampgdk_callback_compare_name(const void *key,

--- a/lib/sampgdk/internal/fakeamx.c
+++ b/lib/sampgdk/internal/fakeamx.c
@@ -174,7 +174,7 @@ int sampgdk_fakeamx_push_array(const cell *src, int size, cell *address) {
     return error;
   }
 
-  dest = sampgdk_array_get(&_sampgdk_fakeamx.heap, *address / sizeof(cell));
+  dest = (cell *)sampgdk_array_get(&_sampgdk_fakeamx.heap, *address / sizeof(cell));
   memcpy(dest, src, size * sizeof(cell));
 
   return 0;
@@ -192,7 +192,7 @@ int sampgdk_fakeamx_push_string(const char *src, int *size, cell *address) {
     return error;
   }
 
-  amx_SetString(sampgdk_array_get(&_sampgdk_fakeamx.heap,
+  amx_SetString((cell *)sampgdk_array_get(&_sampgdk_fakeamx.heap,
                                  *address / sizeof(cell)),
                 src, 0, 0, src_size);
 
@@ -218,7 +218,7 @@ void sampgdk_fakeamx_get_bool(cell address, bool *value) {
   assert(value != NULL);
 
   sampgdk_fakeamx_get_cell(address, &tmp);
-  *value = (bool)tmp;
+  *value = !!tmp;
 }
 
 void sampgdk_fakeamx_get_float(cell address, float *value) {
@@ -238,7 +238,7 @@ void sampgdk_fakeamx_get_array(cell address, cell *dest, int size) {
   assert(dest != NULL);
   assert(size > 0);
 
-  src = sampgdk_array_get(&_sampgdk_fakeamx.heap, address / sizeof(cell));
+  src = (cell *)sampgdk_array_get(&_sampgdk_fakeamx.heap, address / sizeof(cell));
   memcpy(dest, src, size * sizeof(cell));
 }
 

--- a/lib/sampgdk/internal/hook.c
+++ b/lib/sampgdk/internal/hook.c
@@ -211,7 +211,7 @@ sampgdk_hook_t sampgdk_hook_new(void *src, void *dst) {
   size_t orig_size = 0;
   size_t insn_len;
 
-  if ((hook = malloc(sizeof(*hook))) == NULL) {
+  if ((hook = (sampgdk_hook_t)malloc(sizeof(*hook))) == NULL) {
     return NULL;
   }
 

--- a/lib/sampgdk/internal/hook.h
+++ b/lib/sampgdk/internal/hook.h
@@ -26,7 +26,7 @@ void *sampgdk_hook_trampoline(sampgdk_hook_t hook);
 #define SAMPGDK_HOOK_CALL(hook, return_type, args) \
   ((return_type (*)())sampgdk_hook_code(hook))args
 
-#define SAMPGDK_HOOK_CALL_CC(hook, return_type, callconv, args) \
-  ((return_type (callconv *)())sampgdk_hook_trampoline(hook))args
+#define SAMPGDK_HOOK_CALL_CC(hook, return_type, callconv, types, args) \
+  ((return_type (callconv *)types)sampgdk_hook_trampoline(hook))args
 
 #endif /* !SAMPGDK_INTERNAL_HOOK_H */

--- a/lib/sampgdk/internal/log.c
+++ b/lib/sampgdk/internal/log.c
@@ -115,7 +115,7 @@ static void _sampgdk_log_message(int level, const char *format, va_list args) {
       level_string = "";
   }
 
-  real_format = malloc(
+  real_format = (char *)malloc(
     sizeof("[sampgdk:] ") - 1
     + strlen(level_string)
     + strlen(format)

--- a/lib/sampgdk/internal/native.c
+++ b/lib/sampgdk/internal/native.c
@@ -62,7 +62,7 @@ int sampgdk_native_register(const char *name, AMX_NATIVE func) {
    * This allows us to use binary search in sampgdk_native_find().
    */
   for (i = 0; i < _sampgdk_natives.count - 1; i++) {
-    ptr = sampgdk_array_get(&_sampgdk_natives, i);
+    ptr = (AMX_NATIVE_INFO *)sampgdk_array_get(&_sampgdk_natives, i);
     if (strcmp(name, ptr->name) <= 0) {
       break;
     }
@@ -88,7 +88,7 @@ AMX_NATIVE sampgdk_native_find(const char *name) {
     return NULL;
   }
 
-  info = bsearch(name, _sampgdk_natives.data,
+  info = (AMX_NATIVE_INFO *)bsearch(name, _sampgdk_natives.data,
                        _sampgdk_natives.count - 1,
                        _sampgdk_natives.elem_size,
                        _sampgdk_native_compare_bsearch);
@@ -168,7 +168,7 @@ const AMX_NATIVE_INFO *sampgdk_native_get_natives(int *number) {
   if (number != NULL) {
     *number = _sampgdk_natives.count - 1;
   }
-  return _sampgdk_natives.data;
+  return (AMX_NATIVE_INFO *)_sampgdk_natives.data;
 }
 
 cell sampgdk_native_call(AMX_NATIVE native, cell *params) {
@@ -261,13 +261,13 @@ cell sampgdk_native_invoke_array(AMX_NATIVE native, const char *format,
           }
           case 'r': /* const reference */
           case 'R': /* non-const reference */ {
-            cell *ptr = args[i];
+            cell *ptr = (cell *)args[i];
             sampgdk_fakeamx_push_cell(*ptr, &params[i + 1]);
             size[i] = sizeof(cell);
             break;
           }
           case 's': /* const string */ {
-            char *str = args[i];
+            char *str = (char *)args[i];
             int str_size;
             sampgdk_fakeamx_push_string(str, &str_size, &params[i + 1]);
             size[i] = str_size;
@@ -315,7 +315,7 @@ cell sampgdk_native_invoke_array(AMX_NATIVE native, const char *format,
             case 'A':
             case 'S':
               if (size[needs_size] > 0) {
-                sampgdk_fakeamx_push_array(args[needs_size], size[needs_size],
+                sampgdk_fakeamx_push_array((const cell *)args[needs_size], size[needs_size],
                                            &params[needs_size + 1]);
               } else {
                 sampgdk_log_warning("Invalid buffer size");
@@ -350,13 +350,13 @@ cell sampgdk_native_invoke_array(AMX_NATIVE native, const char *format,
        */
       switch (type[i]) {
         case 'R':
-          sampgdk_fakeamx_get_cell(params[i + 1], args[i]);
+          sampgdk_fakeamx_get_cell(params[i + 1], (cell *)args[i]);
           break;
         case 'S':
-          sampgdk_fakeamx_get_string(params[i + 1], args[i], size[i]);
+          sampgdk_fakeamx_get_string(params[i + 1], (char *)args[i], size[i]);
           break;
         case 'A':
-          sampgdk_fakeamx_get_array(params[i + 1], args[i], size[i]);
+          sampgdk_fakeamx_get_array(params[i + 1], (cell *)args[i], size[i]);
           break;
       }
       sampgdk_fakeamx_pop(params[i + 1]);

--- a/lib/sampgdk/internal/param.c
+++ b/lib/sampgdk/internal/param.c
@@ -47,7 +47,7 @@ void sampgdk_param_get_string(AMX *amx, int index, char **param) {
   }
 
   amx_StrLen(phys_addr, &length);
-  string = malloc((length + 1) * sizeof(char));
+  string = (char *)malloc((length + 1) * sizeof(char));
 
   if (amx_GetString(string, phys_addr, 0, length + 1) != AMX_ERR_NONE) {
     free(string);

--- a/lib/sampgdk/internal/plugin.c
+++ b/lib/sampgdk/internal/plugin.c
@@ -73,7 +73,7 @@ int sampgdk_plugin_unregister(void *plugin) {
 void **sampgdk_plugin_get_plugins(int *number) {
   assert(number != NULL);
   *number = _sampgdk_plugins.count;
-  return _sampgdk_plugins.data;
+  return (void **)_sampgdk_plugins.data;
 }
 
 #if SAMPGDK_WINDOWS

--- a/lib/sampgdk/internal/timer.c
+++ b/lib/sampgdk/internal/timer.c
@@ -157,10 +157,10 @@ int sampgdk_timer_set(int interval,
   timer.is_set   = true;
   timer.interval = interval;
   timer.repeat   = repeat;
-  timer.callback = callback;
+  timer.callback = (void *)callback;
   timer.param    = param;
   timer.started  = _sampgdk_timer_now();
-  timer.plugin   = sampgdk_plugin_get_handle(callback);
+  timer.plugin   = sampgdk_plugin_get_handle((void *)callback);
 
   if (timer.started == 0) {
     return 0; /* error already logged */

--- a/lib/sampgdk/internal/timer.c
+++ b/lib/sampgdk/internal/timer.c
@@ -88,7 +88,7 @@ static int _sampgdk_timer_find_slot(void) {
   for (i = 0; i < _sampgdk_timers.count; i++) {
     struct _sampgdk_timer_info *timer;
 
-    timer = sampgdk_array_get(&_sampgdk_timers, i);
+    timer = (struct _sampgdk_timer_info *)sampgdk_array_get(&_sampgdk_timers, i);
     if (!timer->is_set) {
       return i;
     }
@@ -103,12 +103,12 @@ static void _sampgdk_timer_fire(int timerid, int64_t elapsed) {
   int64_t started;
 
   assert(timerid > 0 && timerid <= _sampgdk_timers.count);
-  timer = sampgdk_array_get(&_sampgdk_timers, timerid - 1);
+  timer = (struct _sampgdk_timer_info *)sampgdk_array_get(&_sampgdk_timers, timerid - 1);
 
   assert(timer->is_set);
   started = timer->started;
 
-  sampgdk_log_debug("Firing timer %d, now = %"PRId64", elapsed = %"PRId64,
+  sampgdk_log_debug("Firing timer %d, now = %" PRId64 ", elapsed = %" PRId64,
       timerid, now, elapsed);
   ((sampgdk_timer_callback)timer->callback)(timerid, timer->param);
 
@@ -196,7 +196,7 @@ int sampgdk_timer_kill(int timerid) {
     return -EINVAL;
   }
 
-  timer = sampgdk_array_get(&_sampgdk_timers, timerid - 1);
+  timer = (struct _sampgdk_timer_info *)sampgdk_array_get(&_sampgdk_timers, timerid - 1);
   if (!timer->is_set) {
     return -EINVAL;
   }
@@ -219,7 +219,7 @@ void sampgdk_timer_process_timers(void *plugin) {
   now = _sampgdk_timer_now();
 
   for (i = 0; i < _sampgdk_timers.count; i++) {
-    timer = sampgdk_array_get(&_sampgdk_timers, i);
+    timer = (struct _sampgdk_timer_info *)sampgdk_array_get(&_sampgdk_timers, i);
 
     if (!timer->is_set
         || (plugin != NULL && timer->plugin != plugin)) {

--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -358,12 +358,17 @@ def generate_callback_impl(file, func):
     file.write('  %s %s;\n' % (p.c_type, p.name))
 
   for index, p in enumerate(func.params):
-    file.write('  sampgdk_param_get_%s(amx, %d, (void *)&%s);\n' % ({
+    file.write('  sampgdk_param_get_%s(amx, %d, (%s *)&%s);\n' % ({
         'int'    : 'cell',
         'bool'   : 'bool',
         'float'  : 'float',
         'string' : 'string',
-      }[p.type], index, p.name)
+      }[p.type], index, {
+        'int'    : 'cell',
+        'bool'   : 'bool',
+        'float'  : 'float',
+        'string' : 'char *',
+      }[p.type], p.name)
     )
 
   if func.params:


### PR DESCRIPTION
When you try to use a project with **precompiled headers** or compile the **amalgamation** version as C++ it will give you errors like 

> Conversion from 'void*' to pointer to non-'void' requires an explicit cast

 and

> 'int (__cdecl _)(void)': too many arguments for call_*
