### PR TITLE
Fix binary directory not pointing to correct directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ macro(sampgdk_add_api_gen module_name idl_file api_file)
   add_custom_command(
     OUTPUT ${api_file}
     COMMAND ${PYTHON_EXECUTABLE}
-      ${CMAKE_BINARY_DIR}/scripts/python_wrapper.py
+      ${CMAKE_CURRENT_BINARY_DIR}/scripts/python_wrapper.py
       ${PROJECT_SOURCE_DIR}/scripts/generate_code.py
       --module=${module_name}
       --idl=${idl_file}
@@ -113,7 +113,7 @@ macro(sampgdk_add_source_gen module_name idl_file source_file)
   add_custom_command(
     OUTPUT ${source_file}
     COMMAND ${PYTHON_EXECUTABLE}
-      ${CMAKE_BINARY_DIR}/scripts/python_wrapper.py
+      ${CMAKE_CURRENT_BINARY_DIR}/scripts/python_wrapper.py
       ${PROJECT_SOURCE_DIR}/scripts/generate_code.py
       --module=${module_name}
       --idl=${idl_file}
@@ -126,7 +126,7 @@ macro(sampgdk_add_header_gen module_name idl_file header_file)
   add_custom_command(
     OUTPUT ${header_file}
     COMMAND ${PYTHON_EXECUTABLE}
-      ${CMAKE_BINARY_DIR}/scripts/python_wrapper.py
+      ${CMAKE_CURRENT_BINARY_DIR}/scripts/python_wrapper.py
       ${PROJECT_SOURCE_DIR}/scripts/generate_code.py
       --module=${module_name}
       --idl=${idl_file}


### PR DESCRIPTION
`CMAKE_CURRENT_BINARY_DIR` should be used here instead of `CMAKE_BINARY_DIR` when using in subproject where the output of sub cmake projects could be in `BinaryDirectory/subproject/`, `CMAKE_BINARY_DIR ` points to `BinaryDirectory/` in that case and the python scripts can not be found.