### PR TITLE
Fix invoke_array output string handling

### DIFF
--- a/lib/sampgdk/internal/native.c
+++ b/lib/sampgdk/internal/native.c
@@ -321,12 +321,18 @@ cell sampgdk_native_invoke_array(AMX_NATIVE native, const char *format,
         if (*format_ptr == ']') {
           switch (type[needs_size]) {
             case 'a':
-            case 'A':
-            case 'S':
               if (size[needs_size] > 0) {
                 sampgdk_fakeamx_push_array((const cell *)args[needs_size],
                                            size[needs_size],
                                            &params[needs_size + 1]);
+              } else {
+                sampgdk_log_warning("Invalid buffer size");
+              }
+              break;
+            case 'A':
+            case 'S':
+              if (size[needs_size] > 0) {
+                sampgdk_fakeamx_push(size[needs_size], &params[needs_size + 1]);
               } else {
                 sampgdk_log_warning("Invalid buffer size");
               }


### PR DESCRIPTION
Push output params into fakeamx heap in the same way as individual natives do

The old way led to crashes

A bit about crashes themselves. I experienced behavior that was difficult to reproduce. Calling a native function that is supposed to return a string crashed the server. It didn't happen after a particular amount of callings but after some non-deterministic amount. I repeatedly (every 1 sec) called GetPlayerName and GetAnimationName natives via sampgdk_native_invoke_array. Moreover, that happened only during the first server launch after the OS (Windows 10) startup. Sometimes it happened during the subsequent launches but after the third, it constantly disappeared. I never discovered the other patterns though I came up with a solution.

Your GetPlayerName and GetAnimationName c++ functions didn't crash the server this way so I just changed the way we push output variables into fakeamx heap. That helped. 

The only thing I have doubts about is the return value. For example, if I call GetPlayerName with playerid that has never been connected, I get some nonsense value. If the player was connected but then disconnected, it keeps returning his name. Though GetPlayerName C++ function has the same behavior.